### PR TITLE
Adds a "strong" mode

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -23,7 +23,7 @@ By default, Phraze will generate a passphrase with at least 80 bits of entropy (
 
 You can change the strength of the passphrase Phraze generates, making it either weaker or stronger, a few different ways.
 
-**1. Enable Strong mode.** Use `--strong` to increase minimum entropy from 80 to 105 bits.
+**1. Enable Strong mode.** Use `-S` to increase minimum entropy from 80 bits to 100 bits. Each additional `S` adds another 20 bits of minimum entropy (e.g. `-SS` => 120 bit minimum; `-SSS` => 140 bit minimum).
 
 **2. Set different minimum entropy.** Use `--minimum-entropy` to specify your own minimum amount of entropy, in bits, that your passphrase must have.
 ```bash

--- a/readme.markdown
+++ b/readme.markdown
@@ -21,15 +21,17 @@ curse-argues-valves-unfair-punk-ritual-inlet
 ### Changing the strength of the passphrase
 By default, Phraze will generate a passphrase with at least 80 bits of entropy. But you can change that a few different ways.
 
-**1. Set different minimum entropy** Use `-e` to specify the minimum amount of entropy, in bits, that your passphrase must have.
+**1. Enable Strong mode.** Use `--strong` to increase minimum entropy from 80 up to 105 bits.
+
+**2. Set different minimum entropy.** Use `--minimum-entropy` to specify the minimum amount of entropy, in bits, that your passphrase must have.
 ```bash
-$ phraze -e 105
+$ phraze --minimum-entropy 105
 filmmakers-sands-accounts-spokesman-things-police-victims-winters-griffin
 ```
 
-**2. Set number words** Use `-w` to specify the number of words for Phraze to use. Cannot be used with `-e`/minimum entropy option.
+**3. Set number words.** Use `--words` to specify the number of words for Phraze to use. Cannot be used with `--minimum-entropy` option.
 ```bash
-$ phraze -w 5
+$ phraze --words 5
 determines-generated-frozen-excluded-sleeping
 ```
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -19,15 +19,15 @@ curse-argues-valves-unfair-punk-ritual-inlet
 ## How to use
 
 ### Changing the strength of the passphrase
-By default, Phraze will generate a passphrase with at least 80 bits of entropy. But you can change that.
+By default, Phraze will generate a passphrase with at least 80 bits of entropy. But you can change that a few different ways.
 
-If you want to change the strength of the passphrase, I recommend that you use `-e` to specify the minimum amount of entropy, in bits, that your passphrase must have.
+**1. Set different minimum entropy** Use `-e` to specify the minimum amount of entropy, in bits, that your passphrase must have.
 ```bash
 $ phraze -e 105
 filmmakers-sands-accounts-spokesman-things-police-victims-winters-griffin
 ```
 
-If you want to specify the number words INSTEAD of minimum entropy, you can use `-w` to specify the number of words for Phraze to use. Cannot be used with `-e`/minimum entropy option.
+**2. Set number words** Use `-w` to specify the number of words for Phraze to use. Cannot be used with `-e`/minimum entropy option.
 ```bash
 $ phraze -w 5
 determines-generated-frozen-excluded-sleeping

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,18 +58,18 @@ struct Args {
     #[clap(short = 't', long = "title-case")]
     title_case: bool,
 
-    /// Enable "Secure" mode. Phraze will never output a passphrase with less than 105 bits of
+    /// Enable "Strong" mode. Phraze will never output a passphrase with less than 105 bits of
     /// entropy.
-    #[clap(short = 'S', long = "secure", conflicts_with = "number_of_words")]
-    secure_mode: bool,
+    #[clap(short = 'S', long = "strong", conflicts_with = "number_of_words")]
+    strong_mode: bool,
 }
 
 fn main() {
     let opt = Args::parse();
 
-    // If user enabled secure mode, edit minimum_entropy and number_of_words as needed
-    let (minimum_entropy, number_of_words_desired) = if opt.secure_mode {
-        find_minimum_entropy_for_secure_mode(opt.minimum_entropy)
+    // If user enabled strong mode, edit minimum_entropy and number_of_words as needed
+    let (minimum_entropy, number_of_words_desired) = if opt.strong_mode {
+        find_minimum_entropy_for_strong_mode(opt.minimum_entropy)
     } else {
         (opt.minimum_entropy, opt.number_of_words)
     };
@@ -87,23 +87,23 @@ fn main() {
     );
 }
 
-/// If running in "Secure Mode", check if requested_minimum_entropy is above or below 105 bits.
+/// If running in "Strong Mode", check if requested_minimum_entropy is above or below 105 bits.
 /// If it's below, bump it to 105. If it's above 105, let it pass through.
-fn find_minimum_entropy_for_secure_mode(
+fn find_minimum_entropy_for_strong_mode(
     requested_minimum_entropy: Option<usize>,
 ) -> (Option<usize>, Option<usize>) {
-    const SECURE_MODE_MINIMUM_ENTROPY: usize = 105;
+    const STRONG_MODE_MINIMUM_ENTROPY: usize = 105;
 
     match requested_minimum_entropy {
         Some(entropy) => {
-            if entropy > SECURE_MODE_MINIMUM_ENTROPY {
+            if entropy > STRONG_MODE_MINIMUM_ENTROPY {
                 (Some(entropy), None)
             } else {
-                (Some(SECURE_MODE_MINIMUM_ENTROPY), None)
+                (Some(STRONG_MODE_MINIMUM_ENTROPY), None)
             }
         }
         // No minimum entropy requested. Return 105.
-        None => (Some(SECURE_MODE_MINIMUM_ENTROPY), None),
+        None => (Some(STRONG_MODE_MINIMUM_ENTROPY), None),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ struct Args {
     /// number_of_words is specified, Phraze will default to an 80-bit minimum.
     #[clap(
         short = 'e',
-        long = "minimum_entropy",
+        long = "minimum-entropy",
         conflicts_with = "number_of_words"
     )]
     minimum_entropy: Option<usize>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,21 +57,54 @@ struct Args {
     /// Use Title Case for words in generated usernames
     #[clap(short = 't', long = "title-case")]
     title_case: bool,
+
+    /// Enable "Secure" mode. Phraze will never output a passphrase with less than 105 bits of
+    /// entropy.
+    #[clap(short = 'S', long = "secure", conflicts_with = "number_of_words")]
+    secure_mode: bool,
 }
 
 fn main() {
     let opt = Args::parse();
 
+    // If user enabled secure mode, edit minimum_entropy and number_of_words as needed
+    let (minimum_entropy, number_of_words_desired) = if opt.secure_mode {
+        find_minimum_entropy_for_secure_mode(opt.minimum_entropy)
+    } else {
+        (opt.minimum_entropy, opt.number_of_words)
+    };
+
+    // Generate and print passphrase
     println!(
         "{}",
         generate_passphrase(
-            opt.number_of_words,
-            opt.minimum_entropy,
+            number_of_words_desired,
+            minimum_entropy,
             &opt.separator,
             opt.title_case,
             opt.list_choice,
         )
     );
+}
+
+/// If running in "Secure Mode", check if requested_minimum_entropy is above or below 105 bits.
+/// If it's below, bump it to 105. If it's above 105, let it pass through.
+fn find_minimum_entropy_for_secure_mode(
+    requested_minimum_entropy: Option<usize>,
+) -> (Option<usize>, Option<usize>) {
+    const SECURE_MODE_MINIMUM_ENTROPY: usize = 105;
+
+    match requested_minimum_entropy {
+        Some(entropy) => {
+            if entropy > SECURE_MODE_MINIMUM_ENTROPY {
+                (Some(entropy), None)
+            } else {
+                (Some(SECURE_MODE_MINIMUM_ENTROPY), None)
+            }
+        }
+        // No minimum entropy requested. Return 105.
+        None => (Some(SECURE_MODE_MINIMUM_ENTROPY), None),
+    }
 }
 
 /// Convert list_choice string slice into a List enum. Clap calls this function.


### PR DESCRIPTION
I like that Phraze defaults to 80 bits of entropy. But what if a user (a) knows they want a stronger passphrase than 80, but (b) doesn't want to have to figure out anything much beyond that?

This PR implements what I call "strong mode". If enabled (with `-S`/`--strong`), Phraze will not output a passphrase with less than 105 bits of entropy. 

* If user's requested minimum entropy is _lower_ than 105, it'll bump it up to 105. 
* If user's requested minimum entropy is _higher_ than 105, Phraze will respect that. 

(In other words, if user runs `phraze -S -e 85`, Phraze will output at least 105 bits. If `phrase -S -e 120`, Phraze will output at least 120 bits.) 

* If user specifies a number of words and enables strong mode, it'll throw an error.

I'm not super sure if this is worth the added complexity... Will leave this PR open and unmerged for now.