### PR TITLE
Make list in main function, simplifying generate_passphrase

### DIFF
--- a/benches/generate_passphrase.rs
+++ b/benches/generate_passphrase.rs
@@ -11,7 +11,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     let strength_count = 0;
     let separator = "-";
     let title_case = false;
-    let list_choice = List::Medium;
+    let verbose = false;
+    let wordlist = fetch_list(List::Medium);
 
     group.bench_function("as is", |b| {
         b.iter(|| {
@@ -21,7 +22,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                 strength_count,
                 separator,
                 title_case,
-                list_choice,
+                wordlist,
+                verbose,
             )
         })
     });

--- a/benches/generate_passphrase.rs
+++ b/benches/generate_passphrase.rs
@@ -6,24 +6,19 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("Generate a passphrase");
     group.sample_size(1200).significance_level(0.1);
 
-    let number_of_words = None;
-    let minimum_entropy = Some(80);
-    let strength_count = 0;
+    let number_of_words_to_put_in_passphrase = 7;
     let separator = "-";
     let title_case = false;
-    let verbose = false;
+    // Leaving this outside of the benchmark for now
     let wordlist = fetch_list(List::Medium);
 
     group.bench_function("as is", |b| {
         b.iter(|| {
             generate_passphrase(
-                number_of_words,
-                minimum_entropy,
-                strength_count,
+                number_of_words_to_put_in_passphrase,
                 separator,
                 title_case,
                 wordlist,
-                verbose,
             )
         })
     });

--- a/readme.markdown
+++ b/readme.markdown
@@ -11,7 +11,7 @@ curse-argues-valves-unfair-punk-ritual-inlet
 
 * 🖩 Allows user to set a minimum entropy, freeing them from having to figure how many words from a given list they need to create a strong passphrase
 * 🎯 Only uses uniquely decodable word lists, ensuring that passphrase entropy estimates are accurate, even if no separator is used
-* 🚀 Fast: Takes less than 2 milliseconds to generate a passphrase
+* 🚀 Fast: Takes about 2 milliseconds to generate a passphrase
 * 🛁 Word lists are (hopefully) free of profane words
 * 🔣 Numbers, symbols, and capital letters can be used if a service requires that in a password (`-s _b -t` flags)
 * 🛠️  Written in [Rust](https://www.rust-lang.org/)

--- a/readme.markdown
+++ b/readme.markdown
@@ -142,6 +142,9 @@ Options:
   -t, --title-case
           Use Title Case for words in generated usernames
 
+  -v, --verbose
+          Print estimated entropy of generated passphrase, in bits, along with the passphrase itself
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,29 +79,11 @@ pub fn fetch_list(list_choice: List) -> &'static [&'static str] {
 
 /// Actually generate the passphrase, given a couple neccessary parameters.
 pub fn generate_passphrase(
-    number_of_words: Option<usize>,
-    minimum_entropy: Option<usize>,
-    strength_count: u8,
+    number_of_words_to_put_in_passphrase: usize,
     separator: &str,
     title_case: bool,
     list: &'static [&'static str],
-    verbose: bool,
 ) -> String {
-    // Since user can define a minimum entropy, we might have to do a little math to
-    // figure out how many words we need to include in this passphrase.
-    let number_of_words_to_put_in_passphrase =
-        calculate_number_words_needed(number_of_words, minimum_entropy, strength_count, list.len());
-
-    // If user enabled verbose option
-    if verbose {
-        // print entropy information, but use eprint to only print it
-        // to the terminal
-        eprintln!(
-            "{:.2} bits of entropy in passphrase",
-            (list.len() as f64).log2() * number_of_words_to_put_in_passphrase as f64
-        );
-    }
-
     let mut rng = thread_rng();
     // Create a blank String to put words into to create our passphrase
     let mut passphrase = String::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,15 +84,23 @@ pub fn generate_passphrase(
     strength_count: u8,
     separator: &str,
     title_case: bool,
-    list_choice: List,
+    list: &'static [&'static str],
+    verbose: bool,
 ) -> String {
-    // Go get the actual words (see fetch_list function comment for more info)
-    let list = fetch_list(list_choice);
-
     // Since user can define a minimum entropy, we might have to do a little math to
     // figure out how many words we need to include in this passphrase.
     let number_of_words_to_put_in_passphrase =
         calculate_number_words_needed(number_of_words, minimum_entropy, strength_count, list.len());
+
+    // If user enabled verbose option
+    if verbose {
+        // print entropy information, but use eprint to only print it
+        // to the terminal
+        eprintln!(
+            "{:.2} bits of entropy in passphrase",
+            (list.len() as f64).log2() * number_of_words_to_put_in_passphrase as f64
+        );
+    }
 
     let mut rng = thread_rng();
     // Create a blank String to put words into to create our passphrase

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,20 +81,37 @@ struct Args {
 fn main() {
     let opt = Args::parse();
 
+    // Fetch requested word list
     let list = fetch_list(opt.list_choice);
+
+    // Since user can define a minimum entropy, we might have to do a little math to
+    // figure out how many words we need to include in this passphrase.
+    let number_of_words_to_put_in_passphrase = calculate_number_words_needed(
+        opt.number_of_words,
+        opt.minimum_entropy,
+        opt.strength_count,
+        list.len(),
+    );
+
+    // If user enabled verbose option
+    if opt.verbose {
+        // print entropy information, but use eprint to only print it
+        // to the terminal
+        eprintln!(
+            "{:.2} bits of entropy in passphrase(s)",
+            (list.len() as f64).log2() * number_of_words_to_put_in_passphrase as f64
+        );
+    }
 
     for _ in 0..opt.n_passphrases {
         // Generate and print passphrase
         println!(
             "{}",
             generate_passphrase(
-                opt.number_of_words,
-                opt.minimum_entropy,
-                opt.strength_count,
+                number_of_words_to_put_in_passphrase,
                 &opt.separator,
                 opt.title_case,
                 list,
-                opt.verbose,
             )
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,10 +72,16 @@ struct Args {
     /// Use Title Case for words in generated usernames
     #[clap(short = 't', long = "title-case")]
     title_case: bool,
+
+    /// Print estimated entropy of generated passphrase, in bits, along with the passphrase itself
+    #[clap(short = 'v', long = "verbose")]
+    verbose: bool,
 }
 
 fn main() {
     let opt = Args::parse();
+
+    let list = fetch_list(opt.list_choice);
 
     for _ in 0..opt.n_passphrases {
         // Generate and print passphrase
@@ -87,7 +93,8 @@ fn main() {
                 opt.strength_count,
                 &opt.separator,
                 opt.title_case,
-                opt.list_choice,
+                list,
+                opt.verbose,
             )
         );
     }


### PR DESCRIPTION
* Also adds verbose flag that prints the entropy of the passphrase (not the _minimum_ entropy the user may have inputted).

Strangely, the benchmark slowed down with this change, by about 6%, or 140 ns. I would have expected the opposite.  I'm not really worried about 140 nanoseconds. 