### PR TITLE
Adds option for user to use their own, "custom" word list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,7 @@ dependencies = [
  "clap",
  "criterion",
  "rand",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -604,10 +605,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,7 +373,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "phraze"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "phraze"
 description = "Passphrase generator"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 license = "MPL-2.0"
 readme = "readme.markdown"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["sts10 <sschlinkert@gmail.com>"]
 [dependencies]
 rand = "0.8.5"
 clap = { version = "4.4.7", features = ["derive"] }
+unicode-normalization = "0.1.22"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod unicode_normalization_check;
 use rand::{seq::SliceRandom, thread_rng, Rng};
 
 // Pull in the wordlists as constants for us to use later.
@@ -156,31 +157,4 @@ fn make_title_case(s: &str) -> String {
         None => String::new(),
         Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
     }
-}
-
-// I should move this all in to its own file/module...
-use std::collections::HashSet;
-use unicode_normalization::is_nfc_quick;
-use unicode_normalization::is_nfd_quick;
-use unicode_normalization::is_nfkc_quick;
-use unicode_normalization::is_nfkd_quick;
-use unicode_normalization::IsNormalized;
-
-pub fn uniform_unicode_normalization(list: &[String]) -> bool {
-    let mut types_of_normalizations_discovered = HashSet::new();
-    for word in list {
-        if is_nfc_quick(word.chars()) == IsNormalized::Yes {
-            types_of_normalizations_discovered.insert("NFC");
-        } else if is_nfd_quick(word.chars()) == IsNormalized::Yes {
-            types_of_normalizations_discovered.insert("NFD");
-        } else if is_nfkc_quick(word.chars()) == IsNormalized::Yes {
-            types_of_normalizations_discovered.insert("NFKC");
-        } else if is_nfkd_quick(word.chars()) == IsNormalized::Yes {
-            types_of_normalizations_discovered.insert("NFKD");
-        }
-        if types_of_normalizations_discovered.len() > 1 {
-            return false;
-        }
-    }
-    types_of_normalizations_discovered.len() == 1
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ pub fn convert_minimum_entropy_to_number_of_words(
 
 /// Take enum of list_choice and find the constant that is the corresponding word list (with the
 /// actual words). These are defined in the build script (build.rs)
-pub fn fetch_list(list_choice: List) -> &'static [&'static str] {
+pub fn fetch_list(list_choice: List) -> Vec<String> {
     match list_choice {
         List::Long => WL_LONG,
         List::Medium => WL_MEDIUM,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,3 +157,30 @@ fn make_title_case(s: &str) -> String {
         Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
     }
 }
+
+// I should move this all in to its own file/module...
+use std::collections::HashSet;
+use unicode_normalization::is_nfc_quick;
+use unicode_normalization::is_nfd_quick;
+use unicode_normalization::is_nfkc_quick;
+use unicode_normalization::is_nfkd_quick;
+use unicode_normalization::IsNormalized;
+
+pub fn uniform_unicode_normalization(list: &[String]) -> bool {
+    let mut types_of_normalizations_discovered = HashSet::new();
+    for word in list {
+        if is_nfc_quick(word.chars()) == IsNormalized::Yes {
+            types_of_normalizations_discovered.insert("NFC");
+        } else if is_nfd_quick(word.chars()) == IsNormalized::Yes {
+            types_of_normalizations_discovered.insert("NFD");
+        } else if is_nfkc_quick(word.chars()) == IsNormalized::Yes {
+            types_of_normalizations_discovered.insert("NFKC");
+        } else if is_nfkd_quick(word.chars()) == IsNormalized::Yes {
+            types_of_normalizations_discovered.insert("NFKD");
+        }
+        if types_of_normalizations_discovered.len() > 1 {
+            return false;
+        }
+    }
+    types_of_normalizations_discovered.len() == 1
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,11 +79,14 @@ pub fn fetch_list(list_choice: List) -> &'static [&'static str] {
 }
 
 /// Actually generate the passphrase, given a couple neccessary parameters.
+/// This function uses some Rust magic to be able to accept a word list as
+/// either a &[&str] (built-in word lists) or as a &[String] if user provides a file
+/// as word list.
 pub fn generate_passphrase<T: AsRef<str> + std::fmt::Display>(
     number_of_words_to_put_in_passphrase: usize,
     separator: &str,
     title_case: bool,
-    list: &[T],
+    list: &[T], // Either type!
 ) -> String {
     let mut rng = thread_rng();
     // Create a blank String to put words into to create our passphrase

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ pub fn convert_minimum_entropy_to_number_of_words(
 
 /// Take enum of list_choice and find the constant that is the corresponding word list (with the
 /// actual words). These are defined in the build script (build.rs)
-pub fn fetch_list(list_choice: List) -> Vec<String> {
+pub fn fetch_list(list_choice: List) -> &'static [&'static str] {
     match list_choice {
         List::Long => WL_LONG,
         List::Medium => WL_MEDIUM,
@@ -78,11 +78,11 @@ pub fn fetch_list(list_choice: List) -> Vec<String> {
 }
 
 /// Actually generate the passphrase, given a couple neccessary parameters.
-pub fn generate_passphrase(
+pub fn generate_passphrase<T: AsRef<str> + std::fmt::Display>(
     number_of_words_to_put_in_passphrase: usize,
     separator: &str,
     title_case: bool,
-    list: &'static [&'static str],
+    list: &[T],
 ) -> String {
     let mut rng = thread_rng();
     // Create a blank String to put words into to create our passphrase
@@ -139,7 +139,10 @@ fn get_random_number(rng: &mut impl Rng) -> String {
 
 /// Give an array of words, pick a random element and make it a String for
 /// simplicity's sake.
-fn get_random_element(rng: &mut impl Rng, word_list: &[&str]) -> String {
+fn get_random_element<T: AsRef<str>>(rng: &mut impl Rng, word_list: &[T]) -> String
+where
+    T: std::fmt::Display,
+{
     match word_list.choose(rng) {
         Some(word) => word.to_string(),
         None => panic!("Couldn't pick a random word"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,10 +190,15 @@ fn read_in_custom_list(file_path: &Path) -> Vec<String> {
     };
     let mut word_list: Vec<String> = vec![];
     for line in file_input {
-        if line.to_string().trim() != "" {
-            word_list.push(line.to_string().trim().to_string());
+        // Don't add blank lines or lines made up purely of whitespace
+        if line.trim() != "" {
+            // Remove any starting or trailing whitespace before adding word to list
+            word_list.push(line.trim().to_string());
         }
     }
+    // Remove any duplicate words, since that screws up entropy estimates
+    word_list.sort();
+    word_list.dedup();
     word_list
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,18 +92,18 @@ struct Args {
 fn main() {
     let opt = Args::parse();
 
-    if opt.custom_list_file_path.is_some() && opt.separator == "" && !opt.title_case {
+    if opt.custom_list_file_path.is_some() && opt.separator.is_empty() && !opt.title_case {
         panic!("Must use a separator or title case when using a custom word list");
     }
 
-    // Fetch requested word list
-    let custom_list = match opt.custom_list_file_path {
-        Some(custom_list_file_path) => Some(read_in_custom_list(&custom_list_file_path)),
-        None => None,
-    };
+    // I'd like to have this be one variable (one `let`), but I can't figure out what to type to
+    // make it?
+    let custom_list = opt
+        .custom_list_file_path
+        .map(|custom_list_file_path| read_in_custom_list(&custom_list_file_path));
     let built_in_list = fetch_list(opt.list_choice);
 
-    // Unfortunately, since I can't have just one list variable yet,
+    // Since I can't have just one list variable yet,
     // I need to do this to get the legnth of the list
     let list_length = match custom_list {
         Some(ref custom_list) => custom_list.len(),
@@ -132,6 +132,7 @@ fn main() {
 
     for _ in 0..opt.n_passphrases {
         // Generate and print passphrase
+        // Again, we have more code than we should because of this pesky list type situation...
         let passphrase = match custom_list {
             Some(ref custom_list) => generate_passphrase(
                 number_of_words_to_put_in_passphrase,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use crate::unicode_normalization_check::uniform_unicode_normalization;
 use clap::Parser;
 use phraze::*;
 use std::fs::File;

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,8 @@ fn main() {
         .custom_list_file_path
         .map(|custom_list_file_path| read_in_custom_list(&custom_list_file_path));
     // And another for if the user wants to use a built-in word list
+    // Kind of a bummer, re: perforamnce, that we need to run this even if we're
+    // going to be using the inputted custom list...
     let built_in_list: &'static [&'static str] = fetch_list(opt.list_choice);
 
     // If a "custom_list" was given by the user, we're going to use that list.

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,9 +196,12 @@ fn read_in_custom_list(file_path: &Path) -> Vec<String> {
             word_list.push(line.trim().to_string());
         }
     }
-    // Remove any duplicate words, since that screws up entropy estimates
+    // Remove any duplicate words, since duplicate words would undermine entropy estimates.
     word_list.sort();
     word_list.dedup();
+    if !uniform_unicode_normalization(&word_list) {
+        eprintln!("WARNING: Custom word list has multiple Unicode normalizations.");
+    }
     word_list
 }
 

--- a/src/unicode_normalization_check.rs
+++ b/src/unicode_normalization_check.rs
@@ -46,4 +46,14 @@ fn can_detect_non_uniform_unicode_normalization_in_a_given_list() {
         "charlie".to_string(),
     ];
     assert!(uniform_unicode_normalization(&uniform_list));
+
+    let uniform_list2 = vec![
+        "alpha".to_string(),
+        "beta".to_string(),
+        version1.to_string(), // add one word with an accented character
+        "charlie".to_string(),
+        version1.to_string(), // twice
+    ];
+    // Should still be detected as uniform
+    assert!(uniform_unicode_normalization(&uniform_list2));
 }

--- a/src/unicode_normalization_check.rs
+++ b/src/unicode_normalization_check.rs
@@ -1,0 +1,25 @@
+use std::collections::HashSet;
+use unicode_normalization::is_nfc_quick;
+use unicode_normalization::is_nfd_quick;
+use unicode_normalization::is_nfkc_quick;
+use unicode_normalization::is_nfkd_quick;
+use unicode_normalization::IsNormalized;
+
+pub fn uniform_unicode_normalization(list: &[String]) -> bool {
+    let mut types_of_normalizations_discovered = HashSet::new();
+    for word in list {
+        if is_nfc_quick(word.chars()) == IsNormalized::Yes {
+            types_of_normalizations_discovered.insert("NFC");
+        } else if is_nfd_quick(word.chars()) == IsNormalized::Yes {
+            types_of_normalizations_discovered.insert("NFD");
+        } else if is_nfkc_quick(word.chars()) == IsNormalized::Yes {
+            types_of_normalizations_discovered.insert("NFKC");
+        } else if is_nfkd_quick(word.chars()) == IsNormalized::Yes {
+            types_of_normalizations_discovered.insert("NFKD");
+        }
+        if types_of_normalizations_discovered.len() > 1 {
+            return false;
+        }
+    }
+    types_of_normalizations_discovered.len() == 1
+}

--- a/src/unicode_normalization_check.rs
+++ b/src/unicode_normalization_check.rs
@@ -5,6 +5,13 @@ use unicode_normalization::is_nfkc_quick;
 use unicode_normalization::is_nfkd_quick;
 use unicode_normalization::IsNormalized;
 
+/// Given a slice of Strings, this function will attempt to detect the Unicode normalization used
+/// in each String.
+/// There are 4 different Unicode normalizations: NFC, NFD, NFKC, NFKD. Which ever one lists uses
+/// isn't a concern. What IS a concern is if one list uses MORE THAN ONE normalization.
+/// Thus, this functions counts how many DIFFERENT normalizations it finds. If it's more than 1
+/// type, it returns false, since the list does not have what I call "uniform Unicdoe
+/// normalization." Elsewhere, we warn the user about this.
 pub fn uniform_unicode_normalization(list: &[String]) -> bool {
     let mut types_of_normalizations_discovered = HashSet::new();
     for word in list {
@@ -17,6 +24,8 @@ pub fn uniform_unicode_normalization(list: &[String]) -> bool {
         } else if is_nfkd_quick(word.chars()) == IsNormalized::Yes {
             types_of_normalizations_discovered.insert("NFKD");
         }
+        // If we've already found more than 1 normalization, we can skip the
+        // rest of the list and return false
         if types_of_normalizations_discovered.len() > 1 {
             return false;
         }
@@ -28,8 +37,8 @@ pub fn uniform_unicode_normalization(list: &[String]) -> bool {
 fn can_detect_non_uniform_unicode_normalization_in_a_given_list() {
     let version1 = "sécréter";
     let version2 = "sécréter";
-    let test_list = vec![version1.to_string(), version2.to_string()];
-    assert!(!uniform_unicode_normalization(&test_list));
+    let non_uniform_list = vec![version1.to_string(), version2.to_string()];
+    assert!(!uniform_unicode_normalization(&non_uniform_list));
 
     let uniform_list = vec![
         "alpha".to_string(),

--- a/src/unicode_normalization_check.rs
+++ b/src/unicode_normalization_check.rs
@@ -23,3 +23,18 @@ pub fn uniform_unicode_normalization(list: &[String]) -> bool {
     }
     types_of_normalizations_discovered.len() == 1
 }
+
+#[test]
+fn can_detect_non_uniform_unicode_normalization_in_a_given_list() {
+    let version1 = "sécréter";
+    let version2 = "sécréter";
+    let test_list = vec![version1.to_string(), version2.to_string()];
+    assert!(!uniform_unicode_normalization(&test_list));
+
+    let uniform_list = vec![
+        "alpha".to_string(),
+        "beta".to_string(),
+        "charlie".to_string(),
+    ];
+    assert!(uniform_unicode_normalization(&uniform_list));
+}


### PR DESCRIPTION
Addresses #9. 

Also implements a (case-sensitive) check for duplicates, plus a check for non-uniform Unicode Normalization, on the user-provided lists, hopefully removing some footguns.

I got `generate_passphrase` to take both `&' static [&str]` when using a built-in list and `Vec<String>` when handling a user-provided list, thanks to some Ugly Rust trickery: 

```rust
pub fn generate_passphrase<T: AsRef<str> + std::fmt::Display>(
    number_of_words_to_put_in_passphrase: usize,
    separator: &str,
    title_case: bool,
    list: &[T],
) -> String {
    // ...
}
```

## What I'd like to improve in this PR
The bummer with this PR as it stands is how ugly `src/main.rs` is now. 

```rust
    // I'd like to have this be one variable (one `let`), but I can't figure out what to type to
    // make it?
    let custom_list = opt
        .custom_list_file_path
        .map(|custom_list_file_path| read_in_custom_list(&custom_list_file_path));
    let built_in_list = fetch_list(opt.list_choice);

    // Since I can't have just one list variable yet,
    // I need to do this to get the legnth of the list
    let list_length = match custom_list {
        Some(ref custom_list) => custom_list.len(),
        None => built_in_list.len(),
    };
```

and later
```rust
 // Generate and print passphrase
        // Again, we have more code than we should because of this pesky list type situation...
        let passphrase = match custom_list {
            Some(ref custom_list) => generate_passphrase(
                number_of_words_to_put_in_passphrase,
                &opt.separator,
                opt.title_case,
                custom_list,
            ),
            None => generate_passphrase(
                number_of_words_to_put_in_passphrase,
                &opt.separator,
                opt.title_case,
                built_in_list,
            ),
        };
        println!("{}", passphrase);
```

I'd love to have one type `List` that can handle both `&' static [&str]` when using a built-in list and `Vec<String>` when handling a user-provided list. 

I'm guessing I'll need to implement a trait of some kind? I'm trying to [sketch out the problem in a Rust playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=79806c2d6418369d15a203762a89c889), but it's hard going for me!