### PR TITLE
Add badges (shields?)

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -1,5 +1,6 @@
 # Phraze
-![Crates.io](https://img.shields.io/crates/v/phraze?link=https%3A%2F%2Fcrates.io%2Fcrates%2Fphraze) ![Crates.io](https://img.shields.io/crates/l/phraze)
+[![Crates.io](https://img.shields.io/crates/v/phraze?link=https%3A%2F%2Fcrates.io%2Fcrates%2Fphraze)](https://crates.io/crates/phraze) 
+[![Crates.io](https://img.shields.io/crates/l/phraze)](./LICENSE.txt)
 
 Generate random passphrases.
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -477,7 +477,7 @@ When you're ready to cut a new release, test the current state of the project wi
 
 ## Licensing
 
-Phraze's code is licensed under the Mozilla Public License v2.0 (see included LICENSE.txt file or [this online version of the license](https://www.mozilla.org/en-US/MPL/2.0/)).
+Phraze's code is licensed under the Mozilla Public License v2.0. See included [LICENSE.txt](./LICENSE.txt) file or [this online version of the license](https://www.mozilla.org/en-US/MPL/2.0/).
 
 ### Word list licensing
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -1,4 +1,5 @@
 # Phraze
+![Crates.io](https://img.shields.io/crates/v/phraze?link=https%3A%2F%2Fcrates.io%2Fcrates%2Fphraze) ![Crates.io](https://img.shields.io/crates/l/phraze)
 
 Generate random passphrases.
 


### PR DESCRIPTION
Now that [Phraze is on crates.io](https://crates.io/crates/phraze), I thought it'd be fun to add a little badge or shield showing that off at the top of the README. I also added a badge for the License that Phraze is available under (MPLv2).