### PR TITLE
Switch PRNG to ChaCha20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,7 @@ dependencies = [
  "criterion",
  "include-lines",
  "rand",
+ "rand_chacha",
  "unicode-normalization",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 rand = "0.8.5"
+rand_chacha = "0.3.1"
 clap = { version = "4.4.7", features = ["derive"] }
 unicode-normalization = "0.1.22"
 include-lines = "1.1.2"

--- a/readme.markdown
+++ b/readme.markdown
@@ -453,7 +453,9 @@ gave-model-coil-lent-deep-lam-chin-tall
 
 ## Source of randomness
 
-Phraze uses the [rand crate](https://github.com/rust-random/rand), specifically the [SliceRandom's `choose` method](https://docs.rs/rand/latest/rand/seq/trait.SliceRandom.html#tymethod.choose), which I generally trust as much as any tool for generating randomness with a computer. Though I welcome PRs/issues/ideas on any improvements I could make in this area.
+Phraze uses [ChaCha20](https://docs.rs/rand_chacha/latest/rand_chacha/struct.ChaCha20Rng.html) for its pseudo-random number generator. As the documentation notes: 
+
+> With the ChaCha algorithm it is possible to choose the number of rounds the core algorithm should run. The number of rounds is a tradeoff between performance and security, where 8 rounds is the minimum potentially secure configuration, and 20 rounds is widely used as a conservative choice.
 
 ## Why another random passphrase generator?
 There are already a few good passphrase generators, including [passphraseme](https://github.com/micahflee/passphraseme) and [Pgen](https://github.com/ctsrc/Pgen).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,9 @@ pub mod unicode_normalization_check;
 
 use crate::separators::make_separator;
 use include_lines::include_lines;
-use rand::{seq::SliceRandom, thread_rng, Rng};
+use rand::SeedableRng;
+use rand::{seq::SliceRandom, Rng};
+use rand_chacha::ChaCha20Rng;
 
 /// The possible word lists that Phraze can use.
 #[derive(Clone, Debug, Copy)]
@@ -88,7 +90,7 @@ pub fn generate_a_passphrase<T: AsRef<str> + std::fmt::Display>(
     title_case: bool,
     list: &[T], // Either type!
 ) -> String {
-    let mut rng = thread_rng();
+    let mut rng = ChaCha20Rng::from_entropy();
     // Create a blank String to put words into to create our passphrase
     let mut passphrase = String::new();
     for i in 0..number_of_words_to_put_in_passphrase {


### PR DESCRIPTION
Phraze currently uses `thread_rng` from Rust's rand crate as its pseudo random number generator. 

I think [`thread_rng`, "under the hood," uses a stream cipher called ChaCha12](https://rust-random.github.io/rand/rand/rngs/struct.ThreadRng.html). From what I can tell, this is a good choice!

Buttt I couldn't help but notice the same crate offers "ChaCha20", which is 20 rounds of the same algorithm. As the documentation for [ChaCha20](https://docs.rs/rand_chacha/latest/rand_chacha/struct.ChaCha20Rng.html) notes: 

> With the ChaCha algorithm it is possible to choose the number of rounds the core algorithm should run. The number of rounds is a tradeoff between performance and security, where 8 rounds is the minimum potentially secure configuration, and 20 rounds is widely used as a conservative choice.

Seeing as Phraze can afford to be a little slower in order to become more conservative, this PR explicitly uses 20 rounds (ChaCha20).

However! [Here's a long discussion among cryptographers arguing that 12 rounds is enough and that 20 is overkill!](https://github.com/rust-random/rand/issues/932). But I _still_ thought it'd be interesting to put this PR and see if anyone has any thoughts. 