### PR TITLE
Use one PRNG even if user requests multiple passphrases

### DIFF
--- a/benches/generate_passphrase.rs
+++ b/benches/generate_passphrase.rs
@@ -1,5 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use phraze::*;
+use rand::thread_rng;
 
 fn criterion_benchmark(c: &mut Criterion) {
     // Define a Criterion group, just so we can set a sample_size
@@ -15,11 +16,13 @@ fn criterion_benchmark(c: &mut Criterion) {
             // include the fetching of the (built-in) list
             // in the benchmark
             let wordlist = fetch_list(ListChoice::Medium);
+            let mut rng = thread_rng();
             generate_a_passphrase(
                 number_of_words_to_put_in_passphrase,
                 separator,
                 title_case,
                 wordlist,
+                &mut rng,
             )
         })
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ pub mod unicode_normalization_check;
 
 use crate::separators::make_separator;
 use include_lines::include_lines;
-use rand::{seq::SliceRandom, thread_rng, Rng};
+use rand::{seq::SliceRandom, Rng};
 
 /// The possible word lists that Phraze can use.
 #[derive(Clone, Debug, Copy)]
@@ -87,22 +87,22 @@ pub fn generate_a_passphrase<T: AsRef<str> + std::fmt::Display>(
     separator: &str,
     title_case: bool,
     list: &[T], // Either type!
+    rng: &mut impl Rng,
 ) -> String {
-    let mut rng = thread_rng();
     // Create a blank String to put words into to create our passphrase
     let mut passphrase = String::new();
     for i in 0..number_of_words_to_put_in_passphrase {
         // Check if we're doing title_case
         let random_word = if title_case {
-            make_title_case(&get_random_element(&mut rng, list))
+            make_title_case(&get_random_element(rng, list))
         } else {
-            get_random_element(&mut rng, list)
+            get_random_element(rng, list)
         };
         // Add this word to our passphrase
         passphrase += &random_word;
         // Add a separator
         if i != number_of_words_to_put_in_passphrase - 1 {
-            passphrase += &make_separator(&mut rng, separator);
+            passphrase += &make_separator(rng, separator);
         }
     }
     passphrase.to_string()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use crate::file_reader::read_in_custom_list;
 use clap::Parser;
 use phraze::*;
+use rand::thread_rng;
 use std::path::PathBuf;
 
 /// Generate random passphrases
@@ -126,6 +127,10 @@ fn generate_passphrases<T: AsRef<str> + std::fmt::Display>(opt: &Args, word_list
             opt.n_passphrases,
         );
     }
+    // Create one random number generator for Phraze to use for ALL
+    // generated passphrases. I believe this is more
+    // cryptographically secure/responsible.
+    let mut rng = thread_rng();
 
     // Now we can (finally) generate and print some number of passphrases
     for _ in 0..opt.n_passphrases {
@@ -134,6 +139,7 @@ fn generate_passphrases<T: AsRef<str> + std::fmt::Display>(opt: &Args, word_list
             &opt.separator,
             opt.title_case,
             word_list,
+            &mut rng,
         );
         println!("{}", passphrase);
     }


### PR DESCRIPTION
In my amateur research of CSPRNGs for #21, I came across some cryptographic notes of caution about generating many pseudo-random number generators (I'll try to find some of these links).

The current version of Phraze creats a CSPRNG for each passphrase the user requests. So for example, if the user runs `phraze -n 5` to get 5 passphrases, Phraze creates 5 CSPRNGs, one for each.

In contrast, this PR has Phraze create **one** CSPRNG in `main.rs` and use that to generate all passphrases that the user might ask for.

I'm not yet sure which approach is more safe/secure, but like #21, I'm opening a PR as a question for research/comments/thoughts. Also, of course, it might not really be significant for Phraze.